### PR TITLE
Bump golangci-lint-action to v9 and golangci-lint to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ jobs:
       with:
         go-version-file: "go.mod"
 
-    - uses: golangci/golangci-lint-action@v6
+    - uses: golangci/golangci-lint-action@v9
       with:
-        version: v1.55.2
+        version: v2.12.2
 
   go-apidiff:
     name: go-apidiff

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,17 +1,15 @@
+version: "2"
 run:
   timeout: 5m
 linters:
-  disable-all: true
+  default: none
   enable:
     - govet
     - errcheck
     - staticcheck
     - unused
-    - gosimple
-    - structcheck
-    - varcheck
     - ineffassign
-    - deadcode
-    - typecheck
-    - gofmt
     - goconst
+formatters:
+  enable:
+    - gofmt

--- a/ignore.go
+++ b/ignore.go
@@ -51,7 +51,7 @@ func loadPatterns(root fs.FS, path string) ([]gitignore.Pattern, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	patterns := []gitignore.Pattern{}
 	scanner := bufio.NewScanner(f)

--- a/ignore_test.go
+++ b/ignore_test.go
@@ -7,6 +7,8 @@ import (
 	"testing/fstest"
 )
 
+const testIgnoreFile = ".indexignore"
+
 func TestMatcher(t *testing.T) {
 	type spec struct {
 		ignoreFile    string
@@ -16,7 +18,7 @@ func TestMatcher(t *testing.T) {
 
 	specs := []spec{
 		{
-			ignoreFile: ".indexignore",
+			ignoreFile: testIgnoreFile,
 			fs: fstest.MapFS{
 				".indexignore": &fstest.MapFile{
 					Data: []byte(`


### PR DESCRIPTION
## Summary
- Bump `golangci/golangci-lint-action` from v3 to v9
- Bump golangci-lint from v1.55.2 to v2.12.2
- Migrate `.golangci.yml` to v2 config format: remove deleted linters
  (`structcheck`, `varcheck`, `deadcode` — covered by `unused`), move
  `gofmt` to `formatters` section, replace `disable-all` with `default: none`

## Test plan
- [ ] CI lint job passes with the new action and config

Generated with [Claude Code](https://claude.com/claude-code)